### PR TITLE
Update readme.md Serde to SliceDeque

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,7 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in SliceDeque by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
 [`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html


### PR DESCRIPTION
Probably happened when licensing info was copied from Serde. 