### PR TITLE
bugfix: truncate_{front,back} were not using move_{head,tail}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # dev-dependencies which causes 
 [package]
 name = "slice-deque"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 description = "A double-ended queue that Deref's into a slice."
 documentation = "https://docs.rs/crate/slice-deque/"


### PR DESCRIPTION
Closes #45 .