### PR TITLE
Fix reserve to give amortized growth behaviour

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,7 +691,7 @@ impl<T> SliceDeque<T> {
         let old_len = self.len();
         let req_cap = old_len.checked_add(additional).expect("overflow");
         if req_cap > cur_cap {
-            let dbl_cap = cur_cap * 2;
+            let dbl_cap = cur_cap.saturating_mul(2);
             cmp::max(req_cap, dbl_cap)
         } else {
             req_cap


### PR DESCRIPTION
While ``push_back()`` and ``push_front()`` use grow, ``extend_from_slice()`` and its variants use reserve, which does not give the capacity doubling behaviour needed for amortised constant growth. This leads to small extends of a large buffer having pathologically poor performance. This commit implements behaviour similar to Vec in the standard library, in which ``reserve()`` increases capacity to either the minimum needed capacity or double the existing capacity, whichever is larger. 