### PR TITLE
make OpenBSD uses the fallback of linux instead of using SysV (shm)

### DIFF
--- a/src/mirrored/mod.rs
+++ b/src/mirrored/mod.rs
@@ -8,7 +8,8 @@ mod buffer;
             target_os = "linux",
             target_os = "android",
             target_os = "macos",
-            target_os = "ios"
+            target_os = "ios",
+            target_os = "openbsd"
         ),
         not(feature = "unix_sysv")
     ))
@@ -21,7 +22,8 @@ mod sysv;
             target_os = "linux",
             target_os = "android",
             target_os = "macos",
-            target_os = "ios"
+            target_os = "ios",
+            target_os = "openbsd"
         ),
         not(feature = "unix_sysv")
     ))
@@ -31,12 +33,19 @@ pub(crate) use self::sysv::{
 };
 
 #[cfg(all(
-    any(target_os = "linux", target_os = "android"),
+    any(target_os = "linux",
+        target_os = "android",
+        target_os = "openbsd"
+    ),
     not(feature = "unix_sysv")
 ))]
 mod linux;
 #[cfg(all(
-    any(target_os = "linux", target_os = "android"),
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "openbsd"
+    ),
     not(feature = "unix_sysv")
 ))]
 pub(crate) use self::linux::{


### PR DESCRIPTION
while here, unlink(2) the file created by mkstemp(3) to avoid polluting /tmp

the purpose to not use SysV is to avoid using syscalls not allowed in [pledge(2)](https://man.openbsd.org/pledge.2) context. With `mkstemp(3)`, only filesystem access is required (or just `"tmppath"` promise).

tested on OpenBSD 6.6 -current. All the testsuite passes.