### PR TITLE
feat: impl `std::io::Write` for `SliceDeque<u8>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ default-features = false
 [features]
 default = [ "use_std" ]
 
+unstable = []
+
 # Enables features that require the standard library
 use_std = [ "libc/use_std" ]
 # Enables support for the bytes_buf trait. That is,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,9 @@ impl io::Write for SliceDeque<u8> {
     }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+    fn write_vectored(
+        &mut self, bufs: &[io::IoSlice<'_>],
+    ) -> io::Result<usize> {
         let len = bufs.iter().map(|b| b.len()).sum();
         self.reserve(len);
         for buf in bufs {


### PR DESCRIPTION
I haven't seen any discussion about this on this repo -- I've tried to do my homework, but I realize that this PR is out of the blue and hope that it's welcome. :) It should be a small commitment to review this, though, since the diff is small!

I've run into a case supporting some projects for [`vivint-smarthome`](https://github.com/vivint-smarthome) where having `std::io::Write` would be particularly helpful for interoperation with compression crates like `flate2`.

This particular implementation comes straight from [`std`'s implementation for `Vec<u8>`](https://github.com/rust-lang/rust/blob/6c0b779b7bb23ad1bead914e8023642cc2368406/src/libstd/io/impls.rs#L337).  That means that the correctness of the implementation will just depend on `SliceDeque::{extend_from_slice,reserve}` having the same semantics as their counterparts in `Vec<u8>`, which I believe is the case.