### PR TITLE
Update DrainFilter.idx after calling DrainFilter.pred

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3017,12 +3017,15 @@ where
         unsafe {
             while self.idx != self.old_len {
                 let i = self.idx;
-                self.idx += 1;
                 let v = slice::from_raw_parts_mut(
                     self.deq.as_mut_ptr(),
                     self.old_len,
                 );
-                if (self.pred)(&mut v[i]) {
+                let result = (self.pred)(&mut v[i]);
+                // Update self.idx after calling self.pred
+                // to prevent inconsistent state
+                self.idx += 1;
+                if result {
                     self.del += 1;
                     return Some(ptr::read(&v[i]));
                 } else if self.del > 0 {


### PR DESCRIPTION
Removes security issue where a panic! from DrainFilter.pred
would leave DrainFilter.idx incremented and risking a double drop.

Fixes: #90
